### PR TITLE
Feature/sort all the things

### DIFF
--- a/src/snockets.coffee
+++ b/src/snockets.coffee
@@ -187,7 +187,7 @@ module.exports = class Snockets
   readdir: (dir, flags, callback) ->
     if flags.async
       fs.readdir @absPath(dir), (err, files) ->
-        callback(err, files.sort())
+        callback err, files.sort()
     else
       try
         files = fs.readdirSync @absPath(dir)

--- a/src/snockets.coffee
+++ b/src/snockets.coffee
@@ -186,11 +186,12 @@ module.exports = class Snockets
   # Wrapper around fs.readdir or fs.readdirSync, depending on flags.async.
   readdir: (dir, flags, callback) ->
     if flags.async
-      fs.readdir @absPath(dir), callback
+      fs.readdir @absPath(dir), (err, files) ->
+        callback(err, files.sort())
     else
       try
         files = fs.readdirSync @absPath(dir)
-        callback null, files
+        callback null, files.sort()
       catch e
         callback e
 

--- a/src/snockets.coffee
+++ b/src/snockets.coffee
@@ -12,6 +12,7 @@ module.exports = class Snockets
   constructor: (@options = {}) ->
     @options.src ?= '.'
     @options.async ?= true
+    @options.sort ?= false
     @cache = {}
     @concatCache = {}
     @depGraph = new DepGraph
@@ -23,6 +24,7 @@ module.exports = class Snockets
       callback = flags; flags = {}
     flags ?= {}
     flags.async ?= @options.async
+    flags.sort  ?= @options.sort
 
     @updateDirectives filePath, flags, (err, graphChanged) =>
       if err
@@ -35,6 +37,7 @@ module.exports = class Snockets
       callback = flags; flags = {}
     flags ?= {}
     flags.async ?= @options.async
+    flags.sort  ?= @options.sort
 
     @updateDirectives filePath, flags, (err, graphChanged) =>
       if err
@@ -61,6 +64,7 @@ module.exports = class Snockets
       callback = flags; flags = {}
     flags ?= {}
     flags.async ?= @options.async
+    flags.sort  ?= @options.sort
     concatenationChanged = true
 
     @updateDirectives filePath, flags, (err, graphChanged) =>
@@ -187,11 +191,11 @@ module.exports = class Snockets
   readdir: (dir, flags, callback) ->
     if flags.async
       fs.readdir @absPath(dir), (err, files) ->
-        callback err, files.sort()
+        callback err, if flags.sort then files.sort() else files
     else
       try
         files = fs.readdirSync @absPath(dir)
-        callback null, files.sort()
+        callback null, if flags.sort then files.sort() else files
       catch e
         callback e
 


### PR DESCRIPTION
We are experimenting issues when deploying code that uses snockets. 

If require_tree is used, the order of the requirements may vary from one environment to another. This happens even when in sync mode, because the readdir function may return the items in a different order. 

The solution proposed is to ensure items are sorted before continuing. This, when used in conjuntion with sync mode, will ensure requires are made in alphabetical order, so the behavior won't change from one OS to another. Its paremetrized with a new option in order to mantain backward compatibility.